### PR TITLE
fix: ProfileImage entity

### DIFF
--- a/backend/src/main/java/com/bob/smash/entity/ProfileImage.java
+++ b/backend/src/main/java/com/bob/smash/entity/ProfileImage.java
@@ -11,6 +11,9 @@ import lombok.*;
 @ToString
 public class ProfileImage {
     @Id
+    private Long memberId;
+
+    @MapsId
     @OneToOne
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;


### PR DESCRIPTION
FK를 PK로 받는 경우 @OneToOne과 @JoinColumn을 @Id와 같이 썼을때, JPA가 인식하지 못하는 오류가 있어 @MapsId를 추가하고 @Id 필드를 분리하여 해결